### PR TITLE
Add tax exemption to towns within nation & wealth taxes

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownyFlatFileSource.java
@@ -1135,6 +1135,12 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 					}
 				}
 				
+				line = keys.get("taxexempt");
+				if(line != null) {
+					List<Town> taxExempt = TownyAPI.getInstance().getTowns(line.split(","));
+					nation.setTaxExempt(taxExempt);
+				}
+				
 				line = keys.get("spawnCost");
 				if (line != null)
 					try {
@@ -2104,6 +2110,8 @@ public final class TownyFlatFileSource extends TownyDatabaseHandler {
 		list.add("allies=" + StringMgmt.join(nation.getAllies(), ","));
 
 		list.add("enemies=" + StringMgmt.join(nation.getEnemies(), ","));
+		
+		list.add("taxexempt=" + StringMgmt.join(nation.getTaxExempt(), ","));
 
         // Taxpercent
 		list.add("taxpercent=" + nation.isTaxPercentage());

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -1324,6 +1324,13 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 				for (Nation enemy : enemies) 
 					nation.addEnemy(enemy);
 			}
+			
+			line = rs.getString("taxexempt");
+			if(line != null) {
+				search = (line.contains("#")) ? "#" : ",";
+				List<Town> taxExempt = TownyAPI.getInstance().getTowns(line.split(search));
+				nation.setTaxExempt(taxExempt);
+			}
 
 			nation.setSpawnCost(rs.getFloat("spawnCost"));
 			nation.setNeutral(rs.getBoolean("neutral"));
@@ -2326,6 +2333,7 @@ public final class TownySQLSource extends TownyDatabaseHandler {
 			nat_hm.put("tag", nation.hasTag() ? nation.getTag() : "");
 			nat_hm.put("allies", StringMgmt.join(nation.getAllies(), "#"));
 			nat_hm.put("enemies", StringMgmt.join(nation.getEnemies(), "#"));
+			nat_hm.put("taxexempt", StringMgmt.join(nation.getTaxExempt(), "#"));
 			nat_hm.put("taxes", nation.getTaxes());
             nat_hm.put("taxpercent", nation.isTaxPercentage());
 			nat_hm.put("maxPercentTaxAmount", nation.getMaxPercentTaxAmount());

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/object/Nation.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/object/Nation.java
@@ -39,9 +39,11 @@ public class Nation extends Government {
 
 	private static final String ECONOMY_ACCOUNT_PREFIX = TownySettings.getNationAccountPrefix();
 
+	
 	private final List<Town> towns = new ArrayList<>();
 	private List<Nation> allies = new ArrayList<>();
 	private List<Nation> enemies = new ArrayList<>();
+	private List<Town> taxExempt = new ArrayList<>();
 	private Town capital;
 	private final List<Invite> sentAllyInvites = new ArrayList<>();
 	private boolean isTaxPercentage = TownySettings.getNationDefaultTaxPercentage();
@@ -57,6 +59,18 @@ public class Nation extends Government {
 		setOpen(TownySettings.getNationDefaultOpen());
 	}
 
+	public void addTaxExemptTown(Town town) {
+		if(this.towns.contains(town)) {
+			this.taxExempt.add(town);
+		}
+	}
+	
+	public void removeTaxExemptTown(Town town) {
+		if(this.towns.contains(town)) {
+			this.taxExempt.remove(town);
+		}
+	}
+	
 	public void addAlly(Nation nation) {
 
 		if (!hasAlly(nation)) {
@@ -123,6 +137,26 @@ public class Nation extends Government {
 		return getEnemies().contains(nation);
 	}
 
+	public boolean hasTaxExempt(Town town) {
+		
+		return getTaxExempt().contains(town);
+	}
+	
+	public boolean addTaxExempt(Town town) {
+		if(hasTaxExempt(town)) 
+			return false;
+		else 
+			return getTaxExempt().add(town);
+	}
+	
+	public boolean removeTaxExempt(Town town) {
+		
+		if(!hasTaxExempt(town))
+			return false;
+		else 
+			return getTaxExempt().remove(town);
+	}
+	
 	public List<Town> getTowns() {
 		return Collections.unmodifiableList(towns);
 	}
@@ -285,6 +319,16 @@ public class Nation extends Government {
 	public List<Nation> getAllies() {
 
 		return allies;
+	}
+	
+	public List<Town> getTaxExempt() {
+
+		return taxExempt;
+	}
+	
+	public void setTaxExempt(List<Town> taxExempt) {
+		
+		this.taxExempt = towns;
 	}
 
 	public List<Nation> getMutualAllies() {

--- a/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/tasks/DailyTimerTask.java
@@ -204,6 +204,9 @@ public class DailyTimerTask extends TownyTimerTask {
 
 			if ((town.isCapital() && !TownySettings.doCapitalsPayNationTax()) || !town.hasUpkeep() || town.isRuined())
 				continue;
+			
+			if(nation.hasTaxExempt(town))
+				continue;
 
 			String result = processTownPaysNationTax(town, nation);
 			if (!result.isEmpty())
@@ -249,7 +252,11 @@ public class DailyTimerTask extends TownyTimerTask {
 		double localConqueredTax = 0.0;
 
 		if (nation.isTaxPercentage()) {
-			taxAmount = town.getAccount().getHoldingBalance() * taxAmount / 100;
+			//taxAmount = town.getAccount().getHoldingBalance() * taxAmount / 100;
+			taxAmount = (town.getResidents().stream()
+				.map(v -> v.getAccount().getHoldingBalance())
+				.reduce(town.getAccount().getHoldingBalance(), Double::sum) * 0.25) * (taxAmount / 100);
+				
 			taxAmount = Math.min(taxAmount, nation.getMaxPercentTaxAmount());
 		}
 


### PR DESCRIPTION
## Summary
Adds the option to make towns within a nation tax-exempt, meaning they don't pay taxes. Also changes the formula for tax calculation to the following:
```
((sum(town.residence.balance) + town.balance) * 0.25) * nation.tax_percent
```